### PR TITLE
🐳👷 Adopt devcontainer-based tooling and CI image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+{
+  "name": "jage-dev",
+  "build": {
+    "dockerfile": "../docker/Dockerfile",
+    "context": "..",
+    "args": {
+      "USERNAME": "vscode"
+    }
+  },
+  "remoteUser": "vscode",
+  "containerUser": "vscode",
+  "updateRemoteUserUID": true,
+  "workspaceFolder": "/workspaces/jage",
+  "features": {},
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "C_Cpp.autocomplete": "disabled",
+        "C_Cpp.intelliSenseEngine": "disabled",
+        "C_Cpp.errorSquiggles": "disabled",
+        "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+        "clangd.path": "/usr/bin/clangd",
+        "clangd.arguments": [
+          "--background-index",
+          "--compile-commands-dir=${workspaceFolder}/build",
+          "--header-insertion=never",
+          "-j=8",
+          "--malloc-trim",
+          "--pch-storage=memory",
+          "--clang-tidy",
+          "--enable-config"
+        ],
+        "cmake.configureOnOpen": false,
+        "cmake.sourceDirectory": "${workspaceFolder}",
+        "cmake.configureOnEdit": true,
+        "editor.renderWhitespace": "all",
+        "editor.formatOnSave": true,
+        "cmake.options.statusBarVisibility": "visible",
+        "C_Cpp.default.intelliSenseMode": "linux-gcc-x86"
+      },
+      "extensions": [
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpptools",
+        "llvm-vs-code-extensions.vscode-clangd",
+        "xaver.clang-format",
+        "openai.openai-codex"
+      ]
+    }
+  }
+}

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,67 @@
+name: Build CI Image
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+    paths:
+      - "docker/Dockerfile"
+
+jobs:
+  build-and-push:
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect Dockerfile changes
+        id: dockerfile
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          if git diff --name-only "origin/${{ github.base_ref }}"..."${{ github.event.pull_request.head.sha }}" | grep -q '^docker/Dockerfile$'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Set lowercase owner
+        shell: bash
+        run: echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push (PR)
+        uses: docker/build-push-action@v5
+        if: ${{ github.event_name == 'pull_request' && steps.dockerfile.outputs.changed == 'true' }}
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ env.OWNER_LC }}/jage-ci:${{ github.event.pull_request.head.sha }}
+      - name: Tag latest image with PR head sha
+        if: ${{ github.event_name == 'pull_request' && steps.dockerfile.outputs.changed == 'false' }}
+        shell: bash
+        run: |
+          docker pull ghcr.io/${{ env.OWNER_LC }}/jage-ci:latest
+          docker tag ghcr.io/${{ env.OWNER_LC }}/jage-ci:latest ghcr.io/${{ env.OWNER_LC }}/jage-ci:${{ github.event.pull_request.head.sha }}
+          docker push ghcr.io/${{ env.OWNER_LC }}/jage-ci:${{ github.event.pull_request.head.sha }}
+      - name: Build and push (main)
+        uses: docker/build-push-action@v5
+        if: ${{ github.event_name == 'push' }}
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ env.OWNER_LC }}/jage-ci:latest
+            ghcr.io/${{ env.OWNER_LC }}/jage-ci:${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vcpkg_installed
 CMakeUserPresets.json
 build-*
 scripts/install-all-conan-variants.sh
+.conan

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,48 +1,65 @@
-## Prerequisities
+# Contributing
 
-### Linux
+This document describes how to set up and build the project using either the native toolchain (CMake + Conan) or the provided devcontainer.
 
-#### Install system packages
+## Command line (CMake + Conan)
 
-##### Debian
+Prerequisites:
+- CMake
+- Conan (v2)
+- A C/C++ compiler toolchain
+- Python (for Conan install if needed)
+
+Example setup and build on Linux:
+
 ```bash
-scripts/bootstrap.sh
-```
-#### Install Conan
-
-See [conan package manager installation documentation](https://docs.conan.io/2/installation.html) for most up-to-date information.
-
-Below is an example of how to install conan
-```bash
-cd ~
-python -m venv conan
+# Install Conan in a virtualenv
+python3 -m venv conan
 source conan/bin/activate
 pip install conan
-```
 
-## Building
-
-### Linux
-
-#### Activate Conan
-
-```bash
-source ~/conan/bin/activate
-```
-
-#### Install Build Requirements
-```bash
+# Install dependencies
 conan install . -pr:a profiles/linux -pr:a profiles/gcc -pr:a profiles/debug --build=missing
-```
 
-#### Configure
-```bash
+# Configure
 cmake --preset conan-build-linux-gcc-debug
-```
 
-#### Build
-```bash
+# Build
 cmake --build build --target run-all-jage-unit-tests
 ```
 
+## Dev Containers (VS Code)
 
+Prerequisites:
+- Docker (or Docker Desktop)
+- VS Code
+- VS Code "Dev Containers" extension
+
+Steps:
+1. Open the repo folder in VS Code.
+2. Run "Dev Containers: Reopen in Container" from the Command Palette.
+3. Use the VS Code terminal to run the same Conan/CMake commands as above.
+
+The container image and VS Code extensions are defined in `.devcontainer/devcontainer.json` and `docker/Dockerfile`.
+
+Once inside the VS Code IDE, run the conan install command with the desired profiles, then select the generated CMake configuration preset in VS Code to configure the project.
+
+## Dev Containers (Command line)
+
+Prerequisites:
+- Docker (or Docker Desktop)
+- Node.js and npm
+
+Steps:
+```bash
+# On ubuntu
+sudo apt install nodejs npm
+sudo npm install -g @devcontainers/cli
+
+devcontainer build --workspace-folder /path/to/jage
+devcontainer up --workspace-folder /path/to/jage
+
+devcontainer exec --workspace-folder /path/to/jage -- bash
+```
+
+Once inside the container shell, run the same Conan/CMake commands from the command line section.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,96 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1000
+
+RUN groupadd -g $USER_GID $USERNAME || true \
+  && useradd -m -u $USER_UID -g $USER_GID $USERNAME || true
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  clang-18 \
+  clang++-18 \
+  clangd-18 \
+  clang-tools-18 \
+  cmake \
+  direnv \
+  g++-14 \
+  gcc-14 \
+  git \
+  libgl-dev \
+  libx11-dev \
+  libx11-xcb-dev \
+  libfontenc-dev \
+  libice-dev \
+  libsm-dev \
+  libxau-dev \
+  libxaw7-dev \
+  libxcomposite-dev \
+  libxcursor-dev \
+  libxdamage-dev \
+  libxdmcp-dev \
+  libxext-dev \
+  libxfixes-dev \
+  libxi-dev \
+  libxinerama-dev \
+  libxkbfile-dev \
+  libxmu-dev \
+  libxmuu-dev \
+  libxpm-dev \
+  libxrandr-dev \
+  libxrender-dev \
+  libxres-dev \
+  libxss-dev \
+  libxt-dev \
+  libxtst-dev \
+  libxv-dev \
+  libxxf86vm-dev \
+  libxcb-glx0-dev \
+  libxcb-render0-dev \
+  libxcb-render-util0-dev \
+  libxcb-xkb-dev \
+  libxcb-icccm4-dev \
+  libxcb-image0-dev \
+  libxcb-keysyms1-dev \
+  libxcb-randr0-dev \
+  libxcb-shape0-dev \
+  libxcb-sync-dev \
+  libxcb-xfixes0-dev \
+  libxcb-xinerama0-dev \
+  libxcb-dri3-dev \
+  uuid-dev \
+  libxcb-cursor-dev \
+  libxcb-dri2-0-dev \
+  libxcb-present-dev \
+  libxcb-composite0-dev \
+  libxcb-ewmh-dev \
+  libxcb-res0-dev \
+  libxcb-util-dev \
+  lsb-release \
+  ninja-build \
+  nodejs \
+  npm \
+  pkg-config \
+  python3 \
+  python3-venv \
+  python3-pip \
+  pipx \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/.local/bin:${PATH}"
+
+RUN ln -s /usr/bin/clangd-18 /usr/bin/clangd
+
+RUN npm install -g @openai/codex && npm cache clean --force
+
+USER $USERNAME
+WORKDIR /workspaces
+
+RUN pipx install conan
+RUN python3 -m venv .conan
+RUN eval "$(direnv hook bash)" >> ~/.bashrc
+RUN echo ". ./.conan/bin/activate" >> .envrc
+RUN direnv allow


### PR DESCRIPTION
Problem:
- Bootstrap-based setup was slow and inconsistent across environments
- CI spent time installing system packages on every run
- Contributor onboarding lacked a containerized workflow
- CI image builds were not wired to PRs or the main build pipeline

Solution:
- Add a shared Dockerfile and devcontainer config for local development
- Build/push a CI image and run workflows inside it
- Cache Conan/pip in CI and update CONTRIBUTING with container guidance
- Trigger CI image builds on PRs and chain build/test after image completion
- Remove the bootstrap script in favor of the container setup