### PR TITLE
⬆️  Regenerate requirements.txt from devcontainer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+argcomplete==3.1.4
+click==8.1.6
+colorama==0.4.6
+gyp==0.1
+packaging==24.0
+pipx==1.4.3
+platformdirs==4.2.0
+setuptools==68.1.2
+six==1.16.0
+userpath==1.9.1
+wheel==0.42.0


### PR DESCRIPTION
Reason:
- Host machine had system deps, producing an empty `requirements.txt`