### PR TITLE
🧪 Align input tests with GUnit style; cover 0ns scheduled actions

### DIFF
--- a/test/unit/jage/input/controller_test.cpp
+++ b/test/unit/jage/input/controller_test.cpp
@@ -5,30 +5,36 @@
 
 #include <jage/test/fixtures/input/input_controller.hpp>
 
-#include <gtest/gtest.h>
+#include <GUnit.h>
+#include <gmock/gmock.h>
 
 using jage::test::fixtures::input::input_controller;
 
-TEST_F(input_controller, should_check_button_down) {
-  std::ignore = controller.keyboard().register_callback(null_callback);
-  controller.keyboard().monitor_input(jage::input::keyboard::keys::a);
+GTEST(input_controller) {
+  namespace keyboard = jage::input::keyboard;
+  namespace mouse = jage::input::mouse;
 
-  EXPECT_CALL(driver, keyboard_is_down(jage::input::keyboard::keys::a))
-      .WillOnce(testing::Return(true));
-  controller.poll();
-}
+  SHOULD("Check keyboard button down") {
+    std::ignore = controller.keyboard().register_callback(null_callback);
+    controller.keyboard().monitor_input(keyboard::keys::a);
 
-TEST_F(input_controller, should_check_mouse_button_down) {
-  std::ignore = controller.mouse().register_callback(null_callback);
-  controller.mouse().monitor_input(jage::input::mouse::buttons::left_click);
+    EXPECT_CALL(driver, keyboard_is_down(keyboard::keys::a))
+        .WillOnce(testing::Return(true));
+    controller.poll();
+  }
 
-  EXPECT_CALL(driver, mouse_is_down(jage::input::mouse::buttons::left_click))
-      .WillOnce(testing::Return(true));
-  controller.poll();
-}
+  SHOULD("Check mouse button down") {
+    std::ignore = controller.mouse().register_callback(null_callback);
+    controller.mouse().monitor_input(mouse::buttons::left_click);
 
-TEST_F(input_controller, should_check_cursor_position) {
-  std::ignore = controller.cursor().register_callback(null_callback);
-  EXPECT_CALL(driver, cursor_position()).Times(1);
-  controller.poll();
+    EXPECT_CALL(driver, mouse_is_down(mouse::buttons::left_click))
+        .WillOnce(testing::Return(true));
+    controller.poll();
+  }
+
+  SHOULD("Check cursor position") {
+    std::ignore = controller.cursor().register_callback(null_callback);
+    EXPECT_CALL(driver, cursor_position()).Times(1);
+    controller.poll();
+  }
 }

--- a/test/unit/jage/input/cursor/monitor_test.cpp
+++ b/test/unit/jage/input/cursor/monitor_test.cpp
@@ -3,110 +3,110 @@
 
 #include <jage/test/fixtures/input/cursor/monitoring.hpp>
 
-#include <gtest/gtest.h>
+#include <GUnit.h>
 
 using jage::test::fixtures::input::cursor_monitoring;
 
-TEST_F(cursor_monitoring, should_query_cursor_position) {
-  expect_call_to_cursor_position(state);
+GTEST(cursor_monitoring) {
+  SHOULD("Query cursor position") {
+    expect_call_to_cursor_position(state);
 
-  std::ignore = monitor.register_callback(null_callback);
-  monitor.poll();
-}
+    std::ignore = monitor.register_callback(null_callback);
+    monitor.poll();
+  }
 
-TEST_F(cursor_monitoring,
-       should_not_query_cursor_position_without_registered_callbacks) {
-  expect_call_to_cursor_position();
-  monitor.poll();
-}
+  SHOULD("Not query cursor position without registered callbacks") {
+    expect_call_to_cursor_position();
+    monitor.poll();
+  }
 
-TEST_F(cursor_monitoring, should_invoke_registered_callback) {
-  expect_call_to_cursor_position(state);
-  expect_call_to_callback();
+  SHOULD("Invoke registered callback") {
+    expect_call_to_cursor_position(state);
+    expect_call_to_callback();
 
-  std::ignore = monitor.register_callback(
-      [&](const jage::input::cursor::state &state_arg) -> void {
-        callback.call(state_arg);
-      });
+    std::ignore = monitor.register_callback(
+        [&](const jage::input::cursor::state &state_arg) -> void {
+          callback.call(state_arg);
+        });
 
-  monitor.poll();
-}
+    monitor.poll();
+  }
 
-TEST_F(cursor_monitoring, should_report_correct_cursor_position) {
-  state.x_offset = 42;
-  state.y_offset = 99;
-  expect_call_to_cursor_position(state);
+  SHOULD("Report correct cursor position") {
+    state.x_offset = 42;
+    state.y_offset = 99;
+    expect_call_to_cursor_position(state);
 
-  auto state_output = jage::input::cursor::state{};
-  std::ignore = monitor.register_callback(
-      [&](const jage::input::cursor::state &state_arg) -> void {
-        state_output = state_arg;
-      });
-  monitor.poll();
+    auto state_output = jage::input::cursor::state{};
+    std::ignore = monitor.register_callback(
+        [&](const jage::input::cursor::state &state_arg) -> void {
+          state_output = state_arg;
+        });
+    monitor.poll();
 
-  EXPECT_EQ(state.x_offset, state_output.x_offset);
-  EXPECT_EQ(state.y_offset, state_output.y_offset);
-}
+    EXPECT_EQ(state.x_offset, state_output.x_offset);
+    EXPECT_EQ(state.y_offset, state_output.y_offset);
+  }
 
-TEST_F(cursor_monitoring, should_invoke_all_registered_callbacks) {
-  expect_call_to_cursor_position(state);
-  expect_call_to_callback(2);
+  SHOULD("Invoke all registered callbacks") {
+    expect_call_to_cursor_position(state);
+    expect_call_to_callback(2);
 
-  std::ignore = monitor.register_callback(
-      [&](const jage::input::cursor::state &state_arg) -> void {
-        this->callback.call(state_arg);
-      });
-  std::ignore = monitor.register_callback(
-      [&](const jage::input::cursor::state &state_arg) -> void {
-        this->callback.call(state_arg);
-      });
-  this->monitor.poll();
-}
+    std::ignore = monitor.register_callback(
+        [&](const jage::input::cursor::state &state_arg) -> void {
+          this->callback.call(state_arg);
+        });
+    std::ignore = monitor.register_callback(
+        [&](const jage::input::cursor::state &state_arg) -> void {
+          this->callback.call(state_arg);
+        });
+    this->monitor.poll();
+  }
 
-TEST_F(cursor_monitoring,
-       should_throw_on_attempt_to_register_too_many_callbacks) {
-  std::ignore = monitor.register_callback(
-      [&](const jage::input::cursor::state &state_arg) -> void {
-        this->callback.call(state_arg);
-      });
-  std::ignore = monitor.register_callback(
-      [&](const jage::input::cursor::state &state_arg) -> void {
-        this->callback.call(state_arg);
-      });
-  EXPECT_THROW(std::ignore = monitor.register_callback(
-                   [&](const jage::input::cursor::state &state_arg) -> void {
-                     this->callback.call(state_arg);
-                   });
-               , std::runtime_error);
-}
+  SHOULD("Throw on attempt to register too many callbacks") {
+    std::ignore = monitor.register_callback(
+        [&](const jage::input::cursor::state &state_arg) -> void {
+          this->callback.call(state_arg);
+        });
+    std::ignore = monitor.register_callback(
+        [&](const jage::input::cursor::state &state_arg) -> void {
+          this->callback.call(state_arg);
+        });
+    EXPECT_THROW(std::ignore = monitor.register_callback(
+                     [&](const jage::input::cursor::state &state_arg) -> void {
+                       this->callback.call(state_arg);
+                     });
+                 , std::runtime_error);
+  }
 
-TEST_F(cursor_monitoring, should_be_able_to_deregister_callback) {
-  expect_call_to_cursor_position(state);
-  expect_call_to_callback();
+  SHOULD("Be able to deregister callback") {
+    expect_call_to_cursor_position(state);
+    expect_call_to_callback();
 
-  auto registered_callback = monitor.register_callback(
-      [&](const jage::input::cursor::state &state_arg) -> void {
-        this->callback.call(state_arg);
-      });
-  this->monitor.poll();
-  registered_callback.deregister();
-  this->monitor.poll();
-}
+    auto registered_callback = monitor.register_callback(
+        [&](const jage::input::cursor::state &state_arg) -> void {
+          this->callback.call(state_arg);
+        });
+    this->monitor.poll();
+    registered_callback.deregister();
+    this->monitor.poll();
+  }
 
-TEST_F(cursor_monitoring, should_update_after_deregister) {
-  expect_call_to_cursor_position(state, 2);
-  auto callback0_call_count = 0UZ;
-  auto callback1_call_count = 0UZ;
+  SHOULD("Update after deregister") {
+    expect_call_to_cursor_position(state, 2);
+    auto callback0_call_count = 0UZ;
+    auto callback1_call_count = 0UZ;
 
-  auto registered_callback = monitor.register_callback(
-      [&](const auto &) -> void { ++callback0_call_count; });
+    auto registered_callback = monitor.register_callback(
+        [&](const auto &) -> void { ++callback0_call_count; });
 
-  std::ignore = monitor.register_callback(
-      [&](const auto &) -> void { ++callback1_call_count; });
+    std::ignore = monitor.register_callback(
+        [&](const auto &) -> void { ++callback1_call_count; });
 
-  monitor.poll();
-  registered_callback.deregister();
-  monitor.poll();
-  EXPECT_EQ(1UZ, callback0_call_count);
-  EXPECT_EQ(2UZ, callback1_call_count);
+    monitor.poll();
+    registered_callback.deregister();
+    monitor.poll();
+    EXPECT_EQ(1UZ, callback0_call_count);
+    EXPECT_EQ(2UZ, callback1_call_count);
+  }
 }

--- a/test/unit/jage/scheduled_action_test.cpp
+++ b/test/unit/jage/scheduled_action_test.cpp
@@ -54,6 +54,11 @@ GTEST(scheduled_action_status) {
     scheduled_action.update(1ns);
     EXPECT(scheduled_action_status::complete == scheduled_action.status());
   }
+
+  SHOULD("Complete after 0 ns because default duration is 0 ns") {
+    scheduled_action.update(0ns);
+    EXPECT(scheduled_action_status::complete == scheduled_action.status());
+  }
 }
 
 GTEST(scheduled_action_with_time) {


### PR DESCRIPTION
Reason:
- Keep input unit tests consistent with existing GUnit conventions
- Explicitly verify the default 0ns completion behavior

Changes:
- Migrate input controller/cursor tests to GTEST/SHOULD
- Add a 0ns completion test for scheduled actions