### PR TITLE
🛠️ Devcontainer/CI: Enable local act runs with Docker + an ACT-only job

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,8 @@
     }
   },
   "remoteUser": "vscode",
-  "containerUser": "vscode",
+  "containerUser": "root",
+  "overrideCommand": false,
   "updateRemoteUserUID": true,
   "workspaceFolder": "/workspaces/jage",
   "features": {},
@@ -44,7 +45,8 @@
           "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
         },
         "cmake.options.statusBarVisibility": "visible",
-        "C_Cpp.default.intelliSenseMode": "linux-gcc-x86"
+        "C_Cpp.default.intelliSenseMode": "linux-gcc-x86",
+        "dev.containers.showTerminal": "never"
       },
       "extensions": [
         "ms-vscode.cmake-tools",
@@ -60,6 +62,7 @@
     "source=jage-conan,target=/home/vscode/.conan2,type=volume",
     "source=jage-cache,target=/home/vscode/.cache,type=volume",
     "source=jage-local,target=/home/vscode/.local,type=volume",
-    "source=${localWorkspaceFolder}/journal,target=/home/vscode/journal,type=bind"
+    "source=${localWorkspaceFolder}/journal,target=/home/vscode/journal,type=bind",
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
   ]
 }

--- a/.devcontainer/docker-entrypoint.sh
+++ b/.devcontainer/docker-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+USERNAME="${USERNAME:-vscode}"
+
+align_docker_gid() {
+  if [ -S /var/run/docker.sock ]; then
+    HOST_DOCKER_GID="$(stat -c '%g' /var/run/docker.sock 2>/dev/null || true)"
+    if [ -n "$HOST_DOCKER_GID" ]; then
+      if getent group docker >/dev/null 2>&1; then
+        CONTAINER_DOCKER_GID="$(getent group docker | cut -d: -f3)"
+        if [ "$CONTAINER_DOCKER_GID" != "$HOST_DOCKER_GID" ]; then
+          groupmod -g "$HOST_DOCKER_GID" docker 2>/dev/null \
+            || groupmod -o -g "$HOST_DOCKER_GID" docker 2>/dev/null || true
+        fi
+      else
+        groupadd -g "$HOST_DOCKER_GID" docker 2>/dev/null \
+          || groupadd -o -g "$HOST_DOCKER_GID" docker 2>/dev/null || true
+      fi
+      usermod -aG docker "$USERNAME" 2>/dev/null || true
+    fi
+  fi
+}
+
+align_docker_gid
+
+if [ "$#" -eq 0 ]; then
+  exec runuser -u "$USERNAME" -- /bin/bash
+fi
+
+exec runuser -u "$USERNAME" -- "$@"

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -93,6 +93,8 @@ jobs:
       fail-fast: true
       matrix:
         cpp_compiler: [g++, clang++]
+        build_type: [release, debug]
+        sanitizer: [none, asan, ubsan, tsan, lsan]
         include:
           - cpp_compiler: g++
             c_compiler: gcc
@@ -105,6 +107,16 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.13'
+    - name: set preset
+      shell: bash
+      run: |
+        if [[ "${{ matrix.sanitizer }}" == "none" ]]; then
+          echo "JAGE_CI_PRESET=conan-build-linux-${{ matrix.c_compiler }}-${{ matrix.build_type }}" >> "$GITHUB_ENV"
+          echo "JAGE_CI_PROFILES=-pr:a profiles/linux -pr:a profiles/${{ matrix.c_compiler }} -pr:a profiles/${{ matrix.build_type }}" >> "$GITHUB_ENV"
+        else
+          echo "JAGE_CI_PRESET=conan-build-linux-${{ matrix.c_compiler }}-${{ matrix.build_type }}-${{ matrix.sanitizer }}" >> "$GITHUB_ENV"
+          echo "JAGE_CI_PROFILES=-pr:a profiles/linux -pr:a profiles/${{ matrix.c_compiler }} -pr:a profiles/${{ matrix.build_type }} -pr:a profiles/${{ matrix.sanitizer }}" >> "$GITHUB_ENV"
+        fi
     - name: cache conan
       uses: actions/cache@v4
       if: ${{ !env.ACT }}
@@ -126,12 +138,12 @@ jobs:
       shell: bash
       run: |
         source conan/bin/activate
-        conan install . -pr:a profiles/linux -pr:a profiles/${{ matrix.c_compiler }} -pr:a profiles/release -pr:a profiles/asan -pr:a profiles/ubsan --build=missing
+        conan install . $JAGE_CI_PROFILES --build=missing
     - name: configure cmake
       shell: bash
       run: |
         source conan/bin/activate
-        cmake --preset conan-build-linux-${{ matrix.c_compiler }}-release-asan-ubsan
+        cmake --preset $JAGE_CI_PRESET
     - name: all
       shell: bash
       run: cmake --build build --target all

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=1000
+ARG ACT_VERSION=0.2.61
 
 RUN groupadd -g $USER_GID $USERNAME || true \
   && useradd -m -u $USER_UID -g $USER_GID $USERNAME || true
@@ -25,7 +26,9 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
   clangd-18 \
   clang-tools-18 \
   cmake \
+  curl \
   direnv \
+  docker.io \
   g++-14 \
   gcc-14 \
   git \
@@ -90,7 +93,13 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
   pipx \
   && rm -rf /var/lib/apt/lists/*
 
+RUN usermod -aG docker $USERNAME
+
 ENV PATH="/root/.local/bin:${PATH}"
+
+RUN curl -sSL "https://github.com/nektos/act/releases/download/v${ACT_VERSION}/act_Linux_x86_64.tar.gz" \
+  | tar -xz -C "/usr/local/bin" act
+ENV PATH="/home/${USERNAME}/.local/bin:${PATH}"
 
 RUN ln -s /usr/bin/clangd-18 /usr/bin/clangd
 
@@ -104,3 +113,10 @@ RUN python3 -m venv .conan
 RUN eval "$(direnv hook bash)" >> ~/.bashrc
 RUN echo ". ./.conan/bin/activate" >> .envrc
 RUN direnv allow
+
+USER root
+COPY .devcontainer/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["sleep", "infinity"]
+


### PR DESCRIPTION
Motivation: Make running GitHub Actions locally via act reliable by providing act + Docker access in the devcontainer and a workflow path that doesn’t depend on the image-build job.