### PR TITLE
🕒 time/clock: const snapshot, scale guard, and tests

### DIFF
--- a/include/jage/time/durations.hpp
+++ b/include/jage/time/durations.hpp
@@ -17,6 +17,10 @@ constexpr auto operator""_ms(long double value) -> milliseconds {
   return milliseconds{value};
 }
 
+constexpr auto operator""_ms(unsigned long long value) -> milliseconds {
+  return milliseconds{static_cast<long double>(value)};
+}
+
 constexpr auto operator""_us(long double value) -> microseconds {
   return microseconds{value};
 }

--- a/include/jage/time/internal/clock.hpp
+++ b/include/jage/time/internal/clock.hpp
@@ -4,22 +4,35 @@
 
 #include <jage/time/internal/concepts/real_number_time_source.hpp>
 
-#include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <stdexcept>
 
 namespace jage::time::internal {
 
 template <internal::concepts::real_number_time_source TTimeSource> class clock {
   using duration_ = typename TTimeSource::duration;
-  duration_ tick_duration_;
-  double time_scale_{1.0};
   duration_ elapsed_time_{};
+  duration_ tick_duration_{};
   std::uint64_t elapsed_ticks_{};
+  double time_scale_{1.0};
+
+  struct snapshot {
+    duration_ real_time{};
+    duration_ tick_duration{};
+    double time_scale{1.0};
+    duration_ elapsed_time{};
+    std::uint64_t elapsed_ticks{};
+    duration_ game_time{};
+    std::uint64_t ticks{};
+    duration_ accumulated_time{};
+  };
 
   [[nodiscard]] auto
-  ticks(const duration_ time_elapsed) const -> std::uint64_t {
-    return std::floor(time_elapsed.count() / tick_duration_.count());
+  ticks(const duration_ current_time) const -> std::uint64_t {
+    const auto accumulated_time = current_time - elapsed_time_;
+    return std::floor(accumulated_time.count() / tick_duration_.count()) +
+           elapsed_ticks_;
   }
 
 public:
@@ -33,10 +46,7 @@ public:
   }
 
   [[nodiscard]] auto ticks() const -> std::uint64_t {
-    const auto current_time = real_time() * time_scale_;
-    const auto accumulated_time =
-        std::max(duration{0}, (current_time - elapsed_time_));
-    return ticks(accumulated_time) + elapsed_ticks_;
+    return ticks(real_time() * time_scale_);
   }
 
   [[nodiscard]] auto game_time() const -> duration {
@@ -49,10 +59,34 @@ public:
   }
 
   auto set_time_scale(const double scale) -> void {
+    if (scale < 0.0) [[unlikely]] {
+      throw std::invalid_argument(
+          "Refusing to set time scale to a negative value.");
+    }
     elapsed_ticks_ = ticks();
     elapsed_time_ = real_time() * scale;
 
     time_scale_ = scale;
+  }
+
+  [[nodiscard]] auto snapshot() const -> snapshot {
+    const auto current_real_time = real_time();
+    const auto scaled_real_time = current_real_time * time_scale_;
+    const auto accumulated_time = scaled_real_time - elapsed_time_;
+    const auto accumulated_ticks =
+        std::floor(accumulated_time / tick_duration_);
+    const auto current_ticks = ticks(scaled_real_time);
+    return {
+        .real_time = current_real_time,
+        .tick_duration = tick_duration_,
+        .time_scale = time_scale_,
+        .elapsed_time = elapsed_time_,
+        .elapsed_ticks = elapsed_ticks_,
+        .game_time = duration{current_ticks * tick_duration_.count()},
+        .ticks = current_ticks,
+        .accumulated_time =
+            accumulated_time - accumulated_ticks * tick_duration_,
+    };
   }
 };
 


### PR DESCRIPTION
- compute snapshot values without mutating internal state
- track elapsed state explicitly and reject negative scales
- add snapshot coverage and negative-scale test
- add integer  literal overload