### PR TITLE
🔧 Enforce steady clock sources and formalize snapshots

### DIFF
--- a/cmake/vendor/gunit.cmake
+++ b/cmake/vendor/gunit.cmake
@@ -7,6 +7,15 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(gunit)
 
+# Force GUnit/googletest targets to our preferred standard since the
+# dependency hard-codes CMAKE_CXX_STANDARD internally.
+foreach(t gmock gmock_main gtest gtest_main)
+  if(TARGET ${t})
+    set_property(TARGET ${t} PROPERTY CXX_STANDARD 23)
+    set_property(TARGET ${t} PROPERTY CXX_STANDARD_REQUIRED ON)
+  endif()
+endforeach()
+
 get_target_property(gunit_includes gunit INTERFACE_INCLUDE_DIRECTORIES)
 set_property(TARGET gunit PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
                                    "${gunit_includes}")

--- a/include/jage/time/internal/events/snapshot.hpp
+++ b/include/jage/time/internal/events/snapshot.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <jage/memory/cacheline_size.hpp>
+
+#include <cstdint>
+
+namespace jage::time::internal::events {
+template <class TDuration> struct alignas(memory::cacheline_size) snapshot {
+  TDuration real_time{};
+  TDuration tick_duration{};
+  double time_scale{1.0};
+  TDuration elapsed_time{};
+  std::uint64_t elapsed_ticks{};
+  std::uint64_t ticks{};
+  TDuration accumulated_time{};
+};
+} // namespace jage::time::internal::events

--- a/test/lib/include/jage/test/fakes/time/source.hpp
+++ b/test/lib/include/jage/test/fakes/time/source.hpp
@@ -10,7 +10,7 @@ template <class TDuration> struct source {
   using period = typename TDuration::period;
   using duration = TDuration;
   using time_point = std::chrono::time_point<source>;
-  static constexpr auto is_steady = false;
+  static constexpr auto is_steady = true;
 
   static TDuration current_time;
 

--- a/test/unit/jage/time/internal/clock_test.cpp
+++ b/test/unit/jage/time/internal/clock_test.cpp
@@ -194,7 +194,6 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(1.0, snapshot.time_scale);
     EXPECT_EQ(0UZ, snapshot.ticks);
-    EXPECT_EQ(0_ns, snapshot.game_time);
     EXPECT_EQ(0UZ, snapshot.elapsed_ticks);
     EXPECT_EQ(0_ns, snapshot.elapsed_time);
     EXPECT_EQ(0_ns, snapshot.accumulated_time);
@@ -215,7 +214,6 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(1.0, snapshot.time_scale);
     EXPECT_EQ(1UZ, snapshot.ticks);
-    EXPECT_EQ(100'000_ns, snapshot.game_time);
     EXPECT_EQ(0UZ, snapshot.elapsed_ticks);
     EXPECT_EQ(0_ns, snapshot.elapsed_time);
     EXPECT_EQ(0_ns, snapshot.accumulated_time);
@@ -230,7 +228,6 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(2.0, snapshot.time_scale);
     EXPECT_EQ(1UZ, snapshot.ticks);
-    EXPECT_EQ(100'000_ns, snapshot.game_time);
     EXPECT_EQ(1UZ, snapshot.elapsed_ticks);
     EXPECT_EQ(200'000_ns, snapshot.elapsed_time);
     EXPECT_EQ(0_ns, snapshot.accumulated_time);
@@ -244,7 +241,6 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(150'000_ns, snapshot.real_time);
     EXPECT_EQ(2.0, snapshot.time_scale);
     EXPECT_EQ(2UZ, snapshot.ticks);
-    EXPECT_EQ(200'000_ns, snapshot.game_time);
     EXPECT_EQ(1UZ, snapshot.elapsed_ticks);
     EXPECT_EQ(200'000_ns, snapshot.elapsed_time);
     EXPECT_EQ(0_ns, snapshot.accumulated_time);
@@ -259,7 +255,6 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(2.0, snapshot.time_scale);
     EXPECT_EQ(3UZ, snapshot.ticks);
-    EXPECT_EQ(300'000_ns, snapshot.game_time);
     EXPECT_EQ(1UZ, snapshot.elapsed_ticks);
     EXPECT_EQ(200'000_ns, snapshot.elapsed_time);
   }
@@ -276,7 +271,6 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(0.0, snapshot.time_scale);
     EXPECT_EQ(3UZ, snapshot.ticks);
-    EXPECT_EQ(300'000_ns, snapshot.game_time);
     EXPECT_EQ(3UZ, snapshot.elapsed_ticks);
     EXPECT_EQ(0_ns, snapshot.elapsed_time);
     EXPECT_EQ(0_ns, snapshot.accumulated_time);
@@ -292,7 +286,6 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(1.0, snapshot.time_scale);
     EXPECT_EQ(3UZ, snapshot.ticks);
-    EXPECT_EQ(300'000_ns, snapshot.game_time);
     EXPECT_EQ(3UZ, snapshot.elapsed_ticks);
     EXPECT_EQ(300'000_ns, snapshot.elapsed_time);
     EXPECT_EQ(0_ns, snapshot.accumulated_time);
@@ -308,7 +301,6 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(1.0, snapshot.time_scale);
     EXPECT_EQ(4UZ, snapshot.ticks);
-    EXPECT_EQ(400'000_ns, snapshot.game_time);
     EXPECT_EQ(3UZ, snapshot.elapsed_ticks);
     EXPECT_EQ(300'000_ns, snapshot.elapsed_time);
     EXPECT_EQ(50'000_ns, snapshot.accumulated_time);
@@ -323,7 +315,6 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(0.0, snapshot.time_scale);
     EXPECT_EQ(4UZ, snapshot.ticks);
-    EXPECT_EQ(400'000_ns, snapshot.game_time);
     EXPECT_EQ(4UZ, snapshot.elapsed_ticks);
     EXPECT_EQ(0_ns, snapshot.elapsed_time);
     EXPECT_EQ(0_ns, snapshot.accumulated_time);


### PR DESCRIPTION
Problem:
- clock could be used with non-steady time sources, and snapshots were defined inline without cacheline guarantees
- Snapshot included a redundant game_time field that could drift from ticks

Solution:
- Require is_steady time sources at compile time
- Move snapshot to events::snapshot with cacheline alignment assertions
- Remove snapshot game_time and update tests
- Force gtest/gmock targets to build with C++23