### PR TITLE
🐛 [memory] Do not try to inherit from fundamental types

### DIFF
--- a/test/unit/jage/memory/cacheline_slot_test.cpp
+++ b/test/unit/jage/memory/cacheline_slot_test.cpp
@@ -249,3 +249,16 @@ GTEST("memory cacheline slot") {
     }
   }
 }
+
+GTEST("primative types") {
+  SHOULD("behave like primative type") {
+    {
+      auto slot = cacheline_slot<int>{42};
+      EXPECT_EQ(42, slot);
+    }
+    {
+      auto slot = cacheline_slot{std::numeric_limits<std::uint64_t>::max()};
+      EXPECT_EQ(std::numeric_limits<std::uint64_t>::max(), slot);
+    }
+  }
+}


### PR DESCRIPTION
Problem:
- cacheline_slot instantiated with a fundamental type, like `int`, fails to compile because `int` is final.

Solution:
- Add specialization that does not inherit, but holds a value.

Notes:
- Intentionally made a minimal change here. Additional changes can be made as the use case arises.