### PR TITLE
🏷️ [time] Rename snapshot fields: ticks → frame, elapsed_ticks → elap…

### DIFF
--- a/include/jage/time/internal/clock.hpp
+++ b/include/jage/time/internal/clock.hpp
@@ -79,8 +79,8 @@ public:
         .tick_duration = tick_duration_,
         .time_scale = time_scale_,
         .elapsed_time = elapsed_time_,
-        .elapsed_ticks = elapsed_ticks_,
-        .ticks = current_ticks,
+        .elapsed_frames = elapsed_ticks_,
+        .frame = current_ticks,
         .accumulated_time =
             accumulated_time - accumulated_ticks * tick_duration_,
     };

--- a/include/jage/time/internal/events/snapshot.hpp
+++ b/include/jage/time/internal/events/snapshot.hpp
@@ -10,8 +10,8 @@ template <class TDuration> struct alignas(memory::cacheline_size) snapshot {
   TDuration tick_duration{};
   double time_scale{1.0};
   TDuration elapsed_time{};
-  std::uint64_t elapsed_ticks{};
-  std::uint64_t ticks{};
+  std::uint64_t elapsed_frames{};
+  std::uint64_t frame{};
   TDuration accumulated_time{};
 };
 } // namespace jage::time::internal::events

--- a/test/unit/jage/time/internal/clock_test.cpp
+++ b/test/unit/jage/time/internal/clock_test.cpp
@@ -193,8 +193,8 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(0_ns, snapshot.real_time);
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(1.0, snapshot.time_scale);
-    EXPECT_EQ(0UZ, snapshot.ticks);
-    EXPECT_EQ(0UZ, snapshot.elapsed_ticks);
+    EXPECT_EQ(0UZ, snapshot.frame);
+    EXPECT_EQ(0UZ, snapshot.elapsed_frames);
     EXPECT_EQ(0_ns, snapshot.elapsed_time);
     EXPECT_EQ(0_ns, snapshot.accumulated_time);
   }
@@ -213,8 +213,8 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(100'000_ns, snapshot.real_time);
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(1.0, snapshot.time_scale);
-    EXPECT_EQ(1UZ, snapshot.ticks);
-    EXPECT_EQ(0UZ, snapshot.elapsed_ticks);
+    EXPECT_EQ(1UZ, snapshot.frame);
+    EXPECT_EQ(0UZ, snapshot.elapsed_frames);
     EXPECT_EQ(0_ns, snapshot.elapsed_time);
     EXPECT_EQ(0_ns, snapshot.accumulated_time);
   }
@@ -227,8 +227,8 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(100'000_ns, snapshot.real_time);
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(2.0, snapshot.time_scale);
-    EXPECT_EQ(1UZ, snapshot.ticks);
-    EXPECT_EQ(1UZ, snapshot.elapsed_ticks);
+    EXPECT_EQ(1UZ, snapshot.frame);
+    EXPECT_EQ(1UZ, snapshot.elapsed_frames);
     EXPECT_EQ(200'000_ns, snapshot.elapsed_time);
     EXPECT_EQ(0_ns, snapshot.accumulated_time);
   }
@@ -240,8 +240,8 @@ GTEST("clock: snapshot") {
 
     EXPECT_EQ(150'000_ns, snapshot.real_time);
     EXPECT_EQ(2.0, snapshot.time_scale);
-    EXPECT_EQ(2UZ, snapshot.ticks);
-    EXPECT_EQ(1UZ, snapshot.elapsed_ticks);
+    EXPECT_EQ(2UZ, snapshot.frame);
+    EXPECT_EQ(1UZ, snapshot.elapsed_frames);
     EXPECT_EQ(200'000_ns, snapshot.elapsed_time);
     EXPECT_EQ(0_ns, snapshot.accumulated_time);
   }
@@ -254,8 +254,8 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(200'000_ns, snapshot.real_time);
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(2.0, snapshot.time_scale);
-    EXPECT_EQ(3UZ, snapshot.ticks);
-    EXPECT_EQ(1UZ, snapshot.elapsed_ticks);
+    EXPECT_EQ(3UZ, snapshot.frame);
+    EXPECT_EQ(1UZ, snapshot.elapsed_frames);
     EXPECT_EQ(200'000_ns, snapshot.elapsed_time);
   }
 
@@ -270,8 +270,8 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(300'000_ns, snapshot.real_time);
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(0.0, snapshot.time_scale);
-    EXPECT_EQ(3UZ, snapshot.ticks);
-    EXPECT_EQ(3UZ, snapshot.elapsed_ticks);
+    EXPECT_EQ(3UZ, snapshot.frame);
+    EXPECT_EQ(3UZ, snapshot.elapsed_frames);
     EXPECT_EQ(0_ns, snapshot.elapsed_time);
     EXPECT_EQ(0_ns, snapshot.accumulated_time);
   }
@@ -285,8 +285,8 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(300'000_ns, snapshot.real_time);
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(1.0, snapshot.time_scale);
-    EXPECT_EQ(3UZ, snapshot.ticks);
-    EXPECT_EQ(3UZ, snapshot.elapsed_ticks);
+    EXPECT_EQ(3UZ, snapshot.frame);
+    EXPECT_EQ(3UZ, snapshot.elapsed_frames);
     EXPECT_EQ(300'000_ns, snapshot.elapsed_time);
     EXPECT_EQ(0_ns, snapshot.accumulated_time);
   }
@@ -300,8 +300,8 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(450'000_ns, snapshot.real_time);
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(1.0, snapshot.time_scale);
-    EXPECT_EQ(4UZ, snapshot.ticks);
-    EXPECT_EQ(3UZ, snapshot.elapsed_ticks);
+    EXPECT_EQ(4UZ, snapshot.frame);
+    EXPECT_EQ(3UZ, snapshot.elapsed_frames);
     EXPECT_EQ(300'000_ns, snapshot.elapsed_time);
     EXPECT_EQ(50'000_ns, snapshot.accumulated_time);
   }
@@ -314,8 +314,8 @@ GTEST("clock: snapshot") {
     EXPECT_EQ(450'000_ns, snapshot.real_time);
     EXPECT_EQ(100'000_ns, snapshot.tick_duration);
     EXPECT_EQ(0.0, snapshot.time_scale);
-    EXPECT_EQ(4UZ, snapshot.ticks);
-    EXPECT_EQ(4UZ, snapshot.elapsed_ticks);
+    EXPECT_EQ(4UZ, snapshot.frame);
+    EXPECT_EQ(4UZ, snapshot.elapsed_frames);
     EXPECT_EQ(0_ns, snapshot.elapsed_time);
     EXPECT_EQ(0_ns, snapshot.accumulated_time);
   }


### PR DESCRIPTION
…sed_frames

Clarifies semantic meaning: these fields represent game loop frames, not generic tick counts. The clock still uses ticks() internally for counting, but the snapshot exposes frame-oriented naming for consumers.

Fields renamed:
- elapsed_ticks → elapsed_frames
- ticks → frame